### PR TITLE
changed: trips to be identified by ID rather than strings

### DIFF
--- a/src/components/tile.js
+++ b/src/components/tile.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 function Tile(props) {
 
   const toObject = {
-    pathname: `/${props.type}/${props.text}`,
+    pathname: props.to,
     data: props.data
   };
 
@@ -13,7 +13,7 @@ function Tile(props) {
   return (
     <div>
       <Link to={toObject}>
-        <div class='tile' style={{backgroundImage: `url(${props.imgSrc})`}}>
+        <div class='tile' style={{ backgroundImage: `url(${props.imgSrc})` }}>
           <div class='tile-text'>
             <h2 >{props.text} </h2>
           </div>

--- a/src/pages/trip.js
+++ b/src/pages/trip.js
@@ -1,37 +1,61 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import client from '../contentfulProvider';
 import ReactMarkdown from 'react-markdown';
 
 function Trip(props) {
-
-  const { params } = props.match;
+  // this is just a way of getting state inside functions which... don't have state (does not work on classes)
+  const [isLoading, setIsLoading] = useState(true);
+  const [tripDetails, setTripDetails] = useState({});
 
   console.log("Trip Props: ");
-  console.log(props.location.data);
+  console.log(props.location);
 
-  const data = props.location.data;
+  // // Used only for debugging
+  // function mapPropsToPara(data) {
+  //   const propsList = Object.entries(data).map(([key,value]) => {
+  //     return (
+  //       <p>{key}: {value.toString()}</p>
+  //     )
+  //   });
+  //   return propsList;
+  // }
 
-  // Used only for debugging
-  function mapPropsToPara(data) {
-    const propsList = Object.entries(data).map(([key,value]) => {
-      return (
-        <p>{key}: {value.toString()}</p>
-      )
-    });
-    return propsList;
+  // Think of this as kind of a component did mount...
+  useEffect(() => {
+    const handleDataFetch = async () => {
+      const pageId = props.location.pathname.split('/')[2];
+      // await pattern is the same as using then(), just makes it more streamline
+      const response = await client.getEntry(pageId); // wait for this to resolve, returns response.
+      setTripDetails(response);
+      setIsLoading(false)
+    }
+
+    if (props.location.data) {
+      setTripDetails(props.location.data);
+      setIsLoading(false);
+    } else {
+      handleDataFetch();
+    }
+
+  }, [props.location]);
+
+  // Haven't got the data yet, so hang tight
+  if (isLoading) {
+    return <>"Loading..."</>
   }
 
   return (
     <>
-      <h1>{params.id}</h1>
-      <div class="trip-hero-img">
-        <img src={data.tilePicTrip.fields.file.url} />
-      </div>
-      <ReactMarkdown>{data.tripName}</ReactMarkdown>
-      <ReactMarkdown>{data.tripDate}</ReactMarkdown>
-      <ReactMarkdown>{data.tripLocations}</ReactMarkdown>
-      <ReactMarkdown>{data.highlights}</ReactMarkdown>
-      <ReactMarkdown>{data.tripItinirary}</ReactMarkdown>
-      <ReactMarkdown>{data.tripDetails}</ReactMarkdown>
+      <h1>{tripDetails.fields.tripName}</h1>
+      {tripDetails.fields.tilePicTrip && <div class="trip-hero-img">
+        <img src={tripDetails.fields.tilePicTrip.fields.file.url} alt="" />
+      </div>}
+      <ReactMarkdown>{tripDetails.fields.tripName}</ReactMarkdown>
+      <ReactMarkdown>{tripDetails.fields.tripDate}</ReactMarkdown>
+      <ReactMarkdown>{tripDetails.fields.tripLocations}</ReactMarkdown>
+      <ReactMarkdown>{tripDetails.fields.highlights}</ReactMarkdown>
+      <ReactMarkdown>{tripDetails.fields.tripItinirary}</ReactMarkdown>
+      <ReactMarkdown>{tripDetails.fields.tripDetails}</ReactMarkdown>
     </>
   );
 

--- a/src/pages/trips.js
+++ b/src/pages/trips.js
@@ -7,32 +7,25 @@ class Trips extends React.Component {
   state = { data: [] };
 
   componentDidMount() {
-    client.getEntries({content_type: 'Trip'}).then(response =>
-      this.setState({data: response.items})
+    client.getEntries({ content_type: 'Trip' }).then(response =>
+      this.setState({ data: response.items })
     )
   }
 
-  render () {
-
-    var trips = [];
-
-    if (this.state.data.length) {
-      trips = this.state.data.map((trip, key) => trip.fields);
-      console.log(trips);
-    }
+  render() {
 
     return (
       <div>
         <h1>Trips</h1>
         <div class='tiles'>
-          {trips != null && trips.map(
-            (trip) =>
-            <Tile key={trip.tripName}
-              type='trip'
-              text={trip.tripName}
-              imgSrc={(trip.tilePicTrip != null && trip.tilePicTrip.fields != null) ? trip.tilePicTrip.fields.file.url : undefined}
-              data={trip}
-            />
+          {this.state.data.length && this.state.data.map(
+            (trip) => console.info('trip', trip) ||
+              <Tile key={trip.sys.id}
+                to={`/trip/${trip.sys.id}`}
+                text={trip.fields.tripName}
+                imgSrc={(trip.fields.tilePicTrip && trip.fields.tilePicTrip.fields != null) ? trip.fields.tilePicTrip.fields.file.url : undefined}
+                data={trip}
+              />
           )}
         </div>
       </div>


### PR DESCRIPTION
Found an issue where you couldn't refresh the trip page since it relied on the trips to fetch data and pass it through. So this is a fix to have trips fetch their own data if there's none coming in from props.

Had to turn the URL into an ID based path so that it made it easier to query the entries from Contentful. There's probably a way to query entries via slug, which would make this nicer, but the same structure will work.

(oops, this breaks countries :P )